### PR TITLE
Handle Harvest attributes

### DIFF
--- a/models/yakindu/DeviceMgr.sct
+++ b/models/yakindu/DeviceMgr.sct
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:sgraph="http://www.yakindu.org/sct/sgraph/2.0.0">
-  <sgraph:Statechart xmi:id="_6LQ78PdJEemTQNOn_wVLIw" specification="interface:&#xA;&#x9;in event evClose&#xA;&#x9;in event evOpen&#xA;&#x9;in event evEndOfCycle&#xA;&#x9;operation init()&#xA;&#x9;operation stopPs()&#xA;&#x9;operation startPs()&#xA;&#x9;operation restartPs()" name="DeviceMgr">
+  <sgraph:Statechart xmi:id="_6LQ78PdJEemTQNOn_wVLIw" specification="interface:&#xA;&#x9;in event evClose&#xA;&#x9;in event evOpen&#xA;&#x9;in event evEndOfPolling&#xA;&#x9;operation init()&#xA;&#x9;operation stopPs()&#xA;&#x9;operation startPs()&#xA;&#x9;operation restartPs()" name="DeviceMgr">
     <regions xmi:id="_6LdwQPdJEemTQNOn_wVLIw" name="main region">
       <vertices xsi:type="sgraph:Entry" xmi:id="_6LlsEfdJEemTQNOn_wVLIw">
         <outgoingTransitions xmi:id="_6LrLofdJEemTQNOn_wVLIw" specification="/ init()" target="_6LnhRPdJEemTQNOn_wVLIw"/>
@@ -8,19 +8,21 @@
       <vertices xsi:type="sgraph:State" xmi:id="_6LnhRPdJEemTQNOn_wVLIw" name="Inactive" incomingTransitions="_6LrLofdJEemTQNOn_wVLIw _gxNcEPdMEemTQNOn_wVLIw">
         <outgoingTransitions xmi:id="_0PnyAPdLEemTQNOn_wVLIw" specification="evOpen / startPs()" target="_zLNusfdLEemTQNOn_wVLIw"/>
       </vertices>
-      <vertices xsi:type="sgraph:State" xmi:id="_zLNusfdLEemTQNOn_wVLIw" name="Active" incomingTransitions="_0PnyAPdLEemTQNOn_wVLIw">
+      <vertices xsi:type="sgraph:State" xmi:id="_zLNusfdLEemTQNOn_wVLIw" name="Active" incomingTransitions="_0PnyAPdLEemTQNOn_wVLIw _SJ3GYDMoEeumIbQoFPTMGQ">
         <outgoingTransitions xmi:id="_gxNcEPdMEemTQNOn_wVLIw" specification="evClose / stopPs()" target="_6LnhRPdJEemTQNOn_wVLIw"/>
+        <outgoingTransitions xmi:id="_OcdAgDMoEeumIbQoFPTMGQ" specification="after 1s /* or 0.5s */" target="_Hk3doDMoEeumIbQoFPTMGQ"/>
         <regions xmi:id="_zLPj4_dLEemTQNOn_wVLIw" name="r1">
-          <vertices xsi:type="sgraph:State" xmi:id="_3qJ_MPdLEemTQNOn_wVLIw" name="InCycle" incomingTransitions="_8j1D4PdLEemTQNOn_wVLIw _YmAVMPdMEemTQNOn_wVLIw">
-            <outgoingTransitions xmi:id="_GQOQsPdMEemTQNOn_wVLIw" specification="evEndOfCycle" target="_ERy1IPdMEemTQNOn_wVLIw"/>
+          <vertices xsi:type="sgraph:State" xmi:id="_3qJ_MPdLEemTQNOn_wVLIw" name="Polling" incomingTransitions="_8j1D4PdLEemTQNOn_wVLIw">
+            <outgoingTransitions xmi:id="_GQOQsPdMEemTQNOn_wVLIw" specification="evEndOfPolling" target="_ERy1IPdMEemTQNOn_wVLIw"/>
           </vertices>
           <vertices xsi:type="sgraph:Entry" xmi:id="_72LTsPdLEemTQNOn_wVLIw">
             <outgoingTransitions xmi:id="_8j1D4PdLEemTQNOn_wVLIw" specification="" target="_3qJ_MPdLEemTQNOn_wVLIw"/>
           </vertices>
-          <vertices xsi:type="sgraph:State" xmi:id="_ERy1IPdMEemTQNOn_wVLIw" specification="" name="Idle" incomingTransitions="_GQOQsPdMEemTQNOn_wVLIw">
-            <outgoingTransitions xmi:id="_YmAVMPdMEemTQNOn_wVLIw" specification="after 2s / restartPs()" target="_3qJ_MPdLEemTQNOn_wVLIw"/>
-          </vertices>
+          <vertices xsi:type="sgraph:State" xmi:id="_ERy1IPdMEemTQNOn_wVLIw" specification="" name="WaitEndOfCycle" incomingTransitions="_GQOQsPdMEemTQNOn_wVLIw"/>
         </regions>
+      </vertices>
+      <vertices xsi:type="sgraph:State" xmi:id="_Hk3doDMoEeumIbQoFPTMGQ" name="Starting" incomingTransitions="_OcdAgDMoEeumIbQoFPTMGQ">
+        <outgoingTransitions xmi:id="_SJ3GYDMoEeumIbQoFPTMGQ" specification="always/ restartPs()" target="_zLNusfdLEemTQNOn_wVLIw"/>
       </vertices>
     </regions>
   </sgraph:Statechart>
@@ -58,7 +60,7 @@
           <styles xsi:type="notation:ShapeStyle" xmi:id="_6LovYfdJEemTQNOn_wVLIw" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
           <styles xsi:type="notation:FontStyle" xmi:id="_6LovYvdJEemTQNOn_wVLIw"/>
           <styles xsi:type="notation:BooleanValueStyle" xmi:id="_6LqkkfdJEemTQNOn_wVLIw" name="isHorizontal" booleanValue="true"/>
-          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_6LrLoPdJEemTQNOn_wVLIw" x="12" y="80" width="68" height="53"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_6LrLoPdJEemTQNOn_wVLIw" x="12" y="80" width="93" height="55"/>
         </children>
         <children xmi:id="_zLL5gPdLEemTQNOn_wVLIw" type="State" element="_zLNusfdLEemTQNOn_wVLIw">
           <children xsi:type="notation:DecorationNode" xmi:id="_zLNHo_dLEemTQNOn_wVLIw" type="StateName">
@@ -91,7 +93,7 @@
                   <styles xsi:type="notation:ShapeStyle" xmi:id="_3qKmQfdLEemTQNOn_wVLIw" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
                   <styles xsi:type="notation:FontStyle" xmi:id="_3qKmQvdLEemTQNOn_wVLIw"/>
                   <styles xsi:type="notation:BooleanValueStyle" xmi:id="_3qL0YfdLEemTQNOn_wVLIw" name="isHorizontal" booleanValue="true"/>
-                  <layoutConstraint xsi:type="notation:Bounds" xmi:id="_3qKmQ_dLEemTQNOn_wVLIw" x="5" y="21" width="66" height="76"/>
+                  <layoutConstraint xsi:type="notation:Bounds" xmi:id="_3qKmQ_dLEemTQNOn_wVLIw" x="5" y="21" width="89" height="55"/>
                 </children>
                 <children xmi:id="_72Mh0PdLEemTQNOn_wVLIw" type="Entry" element="_72LTsPdLEemTQNOn_wVLIw">
                   <children xmi:id="_72NI4PdLEemTQNOn_wVLIw" type="BorderItemLabelContainer">
@@ -120,7 +122,7 @@
                   <styles xsi:type="notation:ShapeStyle" xmi:id="_ER0DQfdMEemTQNOn_wVLIw" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
                   <styles xsi:type="notation:FontStyle" xmi:id="_ER0DQvdMEemTQNOn_wVLIw"/>
                   <styles xsi:type="notation:BooleanValueStyle" xmi:id="_ER0qU_dMEemTQNOn_wVLIw" name="isHorizontal" booleanValue="true"/>
-                  <layoutConstraint xsi:type="notation:Bounds" xmi:id="_ER0DQ_dMEemTQNOn_wVLIw" x="268" y="19" width="65" height="81"/>
+                  <layoutConstraint xsi:type="notation:Bounds" xmi:id="_ER0DQ_dMEemTQNOn_wVLIw" x="218" y="19" width="128" height="57"/>
                 </children>
                 <layoutConstraint xsi:type="notation:Bounds" xmi:id="_zLO80_dLEemTQNOn_wVLIw"/>
               </children>
@@ -131,12 +133,28 @@
           <styles xsi:type="notation:ShapeStyle" xmi:id="_zLMgk_dLEemTQNOn_wVLIw" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
           <styles xsi:type="notation:FontStyle" xmi:id="_zLMgkvdLEemTQNOn_wVLIw"/>
           <styles xsi:type="notation:BooleanValueStyle" xmi:id="_zLMgkfdLEemTQNOn_wVLIw" name="isHorizontal" booleanValue="true"/>
-          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_zLMgkPdLEemTQNOn_wVLIw" x="19" y="207" width="373" height="199"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_zLMgkPdLEemTQNOn_wVLIw" x="19" y="207" width="389" height="199"/>
+        </children>
+        <children xmi:id="_Hk9kQDMoEeumIbQoFPTMGQ" type="State" element="_Hk3doDMoEeumIbQoFPTMGQ">
+          <children xsi:type="notation:DecorationNode" xmi:id="_Hk_ZcDMoEeumIbQoFPTMGQ" type="StateName">
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_Hk_ZcTMoEeumIbQoFPTMGQ"/>
+            <layoutConstraint xsi:type="notation:Location" xmi:id="_Hk_ZcjMoEeumIbQoFPTMGQ"/>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_HlAAgDMoEeumIbQoFPTMGQ" type="StateTextCompartment">
+            <children xsi:type="notation:Shape" xmi:id="_HlAnkDMoEeumIbQoFPTMGQ" type="StateTextCompartmentExpression" fontName="Verdana" lineColor="4210752">
+              <layoutConstraint xsi:type="notation:Bounds" xmi:id="_HlAnkTMoEeumIbQoFPTMGQ"/>
+            </children>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_HlAnkjMoEeumIbQoFPTMGQ" type="StateFigureCompartment"/>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_Hk9kQTMoEeumIbQoFPTMGQ" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
+          <styles xsi:type="notation:FontStyle" xmi:id="_Hk9kQjMoEeumIbQoFPTMGQ"/>
+          <styles xsi:type="notation:BooleanValueStyle" xmi:id="_HlAnkzMoEeumIbQoFPTMGQ" name="isHorizontal" booleanValue="true"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_Hk9kQzMoEeumIbQoFPTMGQ" x="112" y="464" width="93" height="55"/>
         </children>
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_6LlFAfdJEemTQNOn_wVLIw"/>
       </children>
       <styles xsi:type="notation:ShapeStyle" xmi:id="_6LhaofdJEemTQNOn_wVLIw" fontName="Verdana" fillColor="15790320" lineColor="12632256"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_6LlsEPdJEemTQNOn_wVLIw" x="20" y="15" width="416" height="459"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_6LlsEPdJEemTQNOn_wVLIw" x="20" y="15" width="450" height="572"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_6LuO8PdJEemTQNOn_wVLIw" type="StatechartText" fontName="Verdana" lineColor="4210752">
       <children xsi:type="notation:DecorationNode" xmi:id="_6Lu2APdJEemTQNOn_wVLIw" type="StatechartName">
@@ -159,7 +177,7 @@
       <styles xsi:type="notation:FontStyle" xmi:id="_6Ltn4PdJEemTQNOn_wVLIw" fontName="Verdana"/>
       <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_6LtA0vdJEemTQNOn_wVLIw" points="[0, 7, 6, -70]$[0, 53, 6, -24]"/>
       <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vsP4APdMEemTQNOn_wVLIw" id="(0.5,0.5)"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vsPQ8PdMEemTQNOn_wVLIw" id="(0.5,0.5)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vsPQ8PdMEemTQNOn_wVLIw" id="(0.35795454545454547,0.48)"/>
     </edges>
     <edges xmi:id="_0PqOQPdLEemTQNOn_wVLIw" type="Transition" element="_0PnyAPdLEemTQNOn_wVLIw" source="_6LovYPdJEemTQNOn_wVLIw" target="_zLL5gPdLEemTQNOn_wVLIw">
       <children xsi:type="notation:DecorationNode" xmi:id="_0PqOQfdLEemTQNOn_wVLIw" type="TransitionExpression">
@@ -169,7 +187,7 @@
       <styles xsi:type="notation:ConnectorStyle" xmi:id="_0PqORPdLEemTQNOn_wVLIw" routing="Rectilinear" lineColor="4210752"/>
       <styles xsi:type="notation:FontStyle" xmi:id="_0PqORfdLEemTQNOn_wVLIw" fontName="Verdana"/>
       <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_0PqORvdLEemTQNOn_wVLIw" points="[22, -16, 2, -179]$[191, -16, 171, -179]$[191, 79, 171, -84]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_0PqOR_dLEemTQNOn_wVLIw" id="(0.6617647058823529,1.0)"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_0PqOR_dLEemTQNOn_wVLIw" id="(0.47376336898395716,0.96)"/>
       <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_0PqOSPdLEemTQNOn_wVLIw" id="(0.14733201581027666,0.4346509671993273)"/>
     </edges>
     <edges xmi:id="_8j1q8PdLEemTQNOn_wVLIw" type="Transition" element="_8j1D4PdLEemTQNOn_wVLIw" source="_72Mh0PdLEemTQNOn_wVLIw" target="_3qKmQPdLEemTQNOn_wVLIw">
@@ -181,7 +199,7 @@
       <styles xsi:type="notation:FontStyle" xmi:id="_8j1q8_dLEemTQNOn_wVLIw" fontName="Verdana"/>
       <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_8j1q8vdLEemTQNOn_wVLIw" points="[-1, 7, -15, -45]$[14, 7, 0, -45]$[14, 28, 0, -24]"/>
       <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_8j4HMPdLEemTQNOn_wVLIw" id="(1.0,0.0)"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="__gJEAPdLEemTQNOn_wVLIw" id="(0.48360655737704916,0.3380281690140845)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="__gJEAPdLEemTQNOn_wVLIw" id="(0.35119047619047616,0.48)"/>
     </edges>
     <edges xmi:id="_GQO3wPdMEemTQNOn_wVLIw" type="Transition" element="_GQOQsPdMEemTQNOn_wVLIw" source="_3qKmQPdLEemTQNOn_wVLIw" target="_ER0DQPdMEemTQNOn_wVLIw">
       <children xsi:type="notation:DecorationNode" xmi:id="_GQO3xPdMEemTQNOn_wVLIw" type="TransitionExpression">
@@ -190,20 +208,9 @@
       </children>
       <styles xsi:type="notation:ConnectorStyle" xmi:id="_GQO3wfdMEemTQNOn_wVLIw" routing="Rectilinear" lineColor="4210752"/>
       <styles xsi:type="notation:FontStyle" xmi:id="_GQO3w_dMEemTQNOn_wVLIw" fontName="Verdana"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_GQO3wvdMEemTQNOn_wVLIw" points="[17, 4, -114, -20]$[132, 48, 1, 24]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_GQQs8PdMEemTQNOn_wVLIw" id="(0.6951844262295082,0.0)"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_KH2pkPdMEemTQNOn_wVLIw" id="(0.95,0.3815789473684211)"/>
-    </edges>
-    <edges xmi:id="_YmA8QPdMEemTQNOn_wVLIw" type="Transition" element="_YmAVMPdMEemTQNOn_wVLIw" source="_ER0DQPdMEemTQNOn_wVLIw" target="_3qKmQPdLEemTQNOn_wVLIw">
-      <children xsi:type="notation:DecorationNode" xmi:id="_YmA8RPdMEemTQNOn_wVLIw" type="TransitionExpression">
-        <styles xsi:type="notation:ShapeStyle" xmi:id="_YmA8RfdMEemTQNOn_wVLIw"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_YmA8RvdMEemTQNOn_wVLIw" x="-2" y="12"/>
-      </children>
-      <styles xsi:type="notation:ConnectorStyle" xmi:id="_YmA8QfdMEemTQNOn_wVLIw" routing="Rectilinear" lineColor="4210752"/>
-      <styles xsi:type="notation:FontStyle" xmi:id="_YmA8Q_dMEemTQNOn_wVLIw" fontName="Verdana"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_YmA8QvdMEemTQNOn_wVLIw" points="[0, 20, 136, 25]$[-129, 20, 7, 25]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_YmCxcPdMEemTQNOn_wVLIw" id="(0.0,0.49665831244778613)"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_YmCxcfdMEemTQNOn_wVLIw" id="(0.8916495901639344,0.43369651873505183)"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_GQO3wvdMEemTQNOn_wVLIw" points="[42, 24, -249, -3]$[171, 24, -120, -3]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_GQQs8PdMEemTQNOn_wVLIw" id="(0.5048363095238095,0.0)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_KH2pkPdMEemTQNOn_wVLIw" id="(0.975609756097561,0.5576923076923077)"/>
     </edges>
     <edges xmi:id="_gxODIPdMEemTQNOn_wVLIw" type="Transition" element="_gxNcEPdMEemTQNOn_wVLIw" source="_zLL5gPdLEemTQNOn_wVLIw" target="_6LovYPdJEemTQNOn_wVLIw">
       <children xsi:type="notation:DecorationNode" xmi:id="_gxOqMvdMEemTQNOn_wVLIw" type="TransitionExpression">
@@ -214,7 +221,29 @@
       <styles xsi:type="notation:FontStyle" xmi:id="_gxOqMfdMEemTQNOn_wVLIw" fontName="Verdana"/>
       <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_gxOqMPdMEemTQNOn_wVLIw" points="[201, 0, 211, 119]$[201, -115, 211, 4]$[2, -115, 12, 4]"/>
       <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_gxQfYPdMEemTQNOn_wVLIw" id="(0.14709944751381215,0.0)"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_gxQfYfdMEemTQNOn_wVLIw" id="(0.8235294117647058,0.16981132075471697)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_gxQfYfdMEemTQNOn_wVLIw" id="(0.589572192513369,0.1630188679245283)"/>
+    </edges>
+    <edges xmi:id="_OcpNwDMoEeumIbQoFPTMGQ" type="Transition" element="_OcdAgDMoEeumIbQoFPTMGQ" source="_zLL5gPdLEemTQNOn_wVLIw" target="_Hk9kQDMoEeumIbQoFPTMGQ">
+      <children xsi:type="notation:DecorationNode" xmi:id="_OcrC8DMoEeumIbQoFPTMGQ" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_OcrC8TMoEeumIbQoFPTMGQ"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_OcrC8jMoEeumIbQoFPTMGQ" y="69"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_OcpNwTMoEeumIbQoFPTMGQ" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_Ocqb4DMoEeumIbQoFPTMGQ" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_OcpNwjMoEeumIbQoFPTMGQ" points="[3, 9, 2, -87]$[3, 72, 2, -24]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_OcvUYDMoEeumIbQoFPTMGQ" id="(0.37789203084832906,0.9547738693467337)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_YGT2sDMoEeumIbQoFPTMGQ" id="(0.6022727272727273,0.48)"/>
+    </edges>
+    <edges xmi:id="_SJ6JsDMoEeumIbQoFPTMGQ" type="Transition" element="_SJ3GYDMoEeumIbQoFPTMGQ" source="_Hk9kQDMoEeumIbQoFPTMGQ" target="_zLL5gPdLEemTQNOn_wVLIw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_SJ7X0DMoEeumIbQoFPTMGQ" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_SJ7X0TMoEeumIbQoFPTMGQ"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_SJ7X0jMoEeumIbQoFPTMGQ" y="10"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_SJ6JsTMoEeumIbQoFPTMGQ" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_SJ6wwDMoEeumIbQoFPTMGQ" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_SJ6JsjMoEeumIbQoFPTMGQ" points="[0, 0, -100, 97]$[104, -91, 4, 6]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_SKCFgDMoEeumIbQoFPTMGQ" id="(1.0,0.579622641509434)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_SKCFgTMoEeumIbQoFPTMGQ" id="(0.7352185089974294,0.9698492462311558)"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/src/Collector/inc/CollectorAct.h
+++ b/src/Collector/inc/CollectorAct.h
@@ -48,6 +48,7 @@ void Collector_deinitBackup(Collector *const me, RKH_EVT_T *pe);
 void Collector_updateFlowmeter(Collector *const me, RKH_EVT_T *pe);
 void Mapping_storeStatus(Mapping *const me, RKH_EVT_T *pe);
 void Mapping_syncDir(Mapping *const me, RKH_EVT_T *pe);
+void Mapping_storeStatusAndSync(Mapping *const me, RKH_EVT_T *pe);
 
 /* ......................... Declares entry actions ........................ */
 void Collector_enActive(Collector *const me);

--- a/src/Collector/src/Collector.c
+++ b/src/Collector/src/Collector.c
@@ -84,7 +84,7 @@ RKH_END_BRANCH_TABLE
 RKH_CREATE_BASIC_STATE(Mapping_Running, Mapping_enRunning,
                        Mapping_exRunning, &Mapping_Active, NULL);
 RKH_CREATE_TRANS_TABLE(Mapping_Running)
-RKH_TRREG(evToutSyncRunning, NULL, Mapping_storeStatus, &Mapping_C3),
+RKH_TRREG(evToutSyncRunning, NULL, Mapping_storeStatusAndSync, &Mapping_C3),
 RKH_TRREG(evNoMapping, NULL, NULL, &Mapping_C2),
 RKH_END_TRANS_TABLE
 

--- a/src/Collector/src/CollectorAct.c
+++ b/src/Collector/src/CollectorAct.c
@@ -303,6 +303,13 @@ Mapping_syncDir(Mapping *const me, RKH_EVT_T *pe)
     me->nStoreLastSync = 0;
 }
 
+void
+Mapping_storeStatusAndSync(Mapping *const me, RKH_EVT_T *pe)
+{
+    storeStatus(me);
+    device_clear(me->itsCollector->dev);
+}
+
 /* ............................. Entry actions ............................. */
 void
 Collector_enActive(Collector *const me)

--- a/src/Collector/test/test_CollectorAct.c
+++ b/src/Collector/test/test_CollectorAct.c
@@ -487,6 +487,45 @@ test_StoreStatus(void)
 }
 
 void
+test_StoreStatusAndSyncWithoutDeviceConnected(void)
+{
+    int n;
+    Mapping *region;
+
+    region = &me->itsMapping;
+    region->itsCollector->dev = (Device *)0;
+    region->nStoreLastSync = n = 20;
+    GStatus_setChecksum_Expect(&region->itsCollector->status);
+    StatQue_put_ExpectAndReturn(0, 0);
+    StatQue_put_IgnoreArg_elem();
+    Backup_store_ExpectAndReturn(&region->itsCollector->status, Backup_Ok);
+    device_clear_Expect(region->itsCollector->dev);
+
+    Mapping_storeStatusAndSync(region, (RKH_EVT_T *)0);
+    TEST_ASSERT_EQUAL(n + 1, me->itsMapping.nStoreLastSync);
+}
+
+void
+test_StoreStatusAndSync(void)
+{
+    int n;
+    Mapping *region;
+    Device device;
+
+    region = &me->itsMapping;
+    region->itsCollector->dev = &device;
+    region->nStoreLastSync = n = 20;
+    GStatus_setChecksum_Expect(&region->itsCollector->status);
+    StatQue_put_ExpectAndReturn(0, 0);
+    StatQue_put_IgnoreArg_elem();
+    Backup_store_ExpectAndReturn(&region->itsCollector->status, Backup_Ok);
+    device_clear_Expect(region->itsCollector->dev);
+
+    Mapping_storeStatusAndSync(region, (RKH_EVT_T *)0);
+    TEST_ASSERT_EQUAL(n + 1, me->itsMapping.nStoreLastSync);
+}
+
+void
 test_syncDir(void)
 {
     Mapping *region;

--- a/src/Config/inc/Config.h
+++ b/src/Config/inc/Config.h
@@ -86,9 +86,10 @@ struct Config
     rui8_t connTime;
 
     /**
-     * Every devPollCycleTime seconds a polling cycle starts over the RS485.
+     * Every devPollCycleTime milliseconds a polling cycle starts over the 
+     * RS485.
      */
-    rui8_t devPollCycleTime;
+    rui16_t devPollCycleTime;
 
     /**
      * Max. number of frames (status) to send in a multiframe message.
@@ -182,8 +183,8 @@ void Config_setMapTimeOnStopped(rui8_t value);
 rui8_t Config_getMapTimeOnStopped(void);
 void Config_setConnTime(rui8_t value);
 rui8_t Config_getConnTime(void);
-void Config_setDevPollCycleTime(rui8_t value);
-rui8_t Config_getDevPollCycleTime(void);
+void Config_setDevPollCycleTime(rui16_t value);
+rui16_t Config_getDevPollCycleTime(void);
 void Config_setMaxNumFramesToSend(rui16_t value);
 rui16_t Config_getMaxNumFramesToSend(void);
 void Config_setUpdateGPSTime(rui8_t value);

--- a/src/Config/src/Config.c
+++ b/src/Config/src/Config.c
@@ -288,7 +288,7 @@ Config_getConnTime(void)
 }
 
 void
-Config_setDevPollCycleTime(rui8_t value)
+Config_setDevPollCycleTime(rui16_t value)
 {
     Config *cfg;
 
@@ -297,7 +297,7 @@ Config_setDevPollCycleTime(rui8_t value)
     Config_set(cfg);
 }
 
-rui8_t
+rui16_t
 Config_getDevPollCycleTime(void)
 {
     Config *cfg;

--- a/src/DeviceMgr/inc/DeviceMgr.h
+++ b/src/DeviceMgr/inc/DeviceMgr.h
@@ -11,6 +11,7 @@
 /* -------------------------------- Authors -------------------------------- */
 /*
  *  DaBa  Dario Baliña db@vortexmakes.com
+ *  LeFr  Leandro Francucci lf@vortexmakes.com
  */
 
 /* --------------------------------- Notes --------------------------------- */
@@ -28,9 +29,6 @@ extern "C" {
 
 /* --------------------------------- Macros -------------------------------- */
 /* -------------------------------- Constants ------------------------------ */
-#define DEV_MAX_NUM_TRIES       10
-#define DEV_MAX_NUM_BACKOFF     5
-
 /* ................................ Signals ................................ */
 /* ........................ Declares active object ......................... */
 typedef struct DeviceMgr DeviceMgr;
@@ -38,10 +36,7 @@ struct DeviceMgr
 {
     RKH_SMA_T ao;       /* Base structure */
     RKHTmEvt tmr;
-    uint32_t pollCycle;
-    uint32_t tries;
-    uint32_t backoff;
-    uint32_t enableBackoff;
+    uint32_t pollPer;   /* Polling period */
 };
 
 RKH_SMA_DCLR_TYPE(DeviceMgr, deviceMgr);

--- a/src/device/inc/device.h
+++ b/src/device/inc/device.h
@@ -61,6 +61,9 @@ typedef bool (*UpdateOper)(Device *const me, RKH_EVT_T *evt);
 /** Collector transforms device's data to CBOX_STR class */
 typedef void (*UpdateRawOper)(Device *const me);
 
+/** Collector clear device's data */
+typedef void (*ClearOper)(Device *const me);
+
 struct JobCond
 {
     int id;
@@ -72,6 +75,7 @@ struct DevVtbl
     MakeEvtOper makeEvt;
     UpdateOper update;
     UpdateRawOper updateRaw;
+    ClearOper clear;
 };
 
 struct Device
@@ -97,6 +101,7 @@ RKH_EVT_T *device_makeEvt(Device *const me, CBOX_STR *rawData);
 bool device_update(Device *const me, RKH_EVT_T *evt);
 int device_test(Device *const me);
 void device_updateRaw(Device *const me);
+void device_clear(Device *const me);
 
 /* -------------------- External C language linkage end -------------------- */
 #ifdef __cplusplus

--- a/src/device/src/Harvest.c
+++ b/src/device/src/Harvest.c
@@ -85,10 +85,24 @@ Harvest_updateRaw(Device *const me)
     rawData->h.flow = ((Harvest *)me)->flow;
 }
 
+static void
+Harvest_clear(Device *const me)
+{
+    Harvest *realMe;
+    Collector *collector;
+
+    collector = (Collector *)(me->collector);
+    realMe = (Harvest *)(collector->dev);
+    realMe->hoard = 0;
+    realMe->nPail = 0;
+    realMe->flow = 0;
+}
+
 static DevVtbl vtbl = {Harvest_test,
                        Harvest_makeEvt,
                        Harvest_update,
-                       Harvest_updateRaw};
+                       Harvest_updateRaw,
+                       Harvest_clear};
 
 /* ---------------------------- Global functions --------------------------- */
 Device *

--- a/src/device/src/Harvest.c
+++ b/src/device/src/Harvest.c
@@ -69,9 +69,9 @@ Harvest_update(Device *const me, RKH_EVT_T *evt)
     collector->dev = realEvt->base.dev;
     collector->status.data.devData.a.x = collector->dev->id;
     currDev = (Harvest *)(collector->dev);
-    currDev->hoard = realEvt->hoard;
-    currDev->nPail = realEvt->nPail;
-    currDev->flow = realEvt->flow;
+    currDev->hoard += realEvt->hoard;
+    currDev->nPail += realEvt->nPail;
+    currDev->flow += realEvt->flow;
     return false;
 }
 

--- a/src/device/src/Sampler.c
+++ b/src/device/src/Sampler.c
@@ -88,7 +88,8 @@ Sampler_updateRaw(Device *const me)
 static DevVtbl vtbl = {Sampler_test,
                        Sampler_makeEvt,
                        Sampler_update,
-                       Sampler_updateRaw};
+                       Sampler_updateRaw,
+                       (ClearOper)0};
 
 /* ---------------------------- Global functions --------------------------- */
 Device *

--- a/src/device/src/Skeleton.c
+++ b/src/device/src/Skeleton.c
@@ -79,10 +79,22 @@ Skeleton_updateRaw(Device *const me)
     rawData->hum = ((Skeleton *)me)->x;
 }
 
+static void
+Skeleton_clear(Device *const me)
+{
+    Skeleton *currDev;
+    Collector *collector;
+
+    collector = (Collector *)(me->collector);
+    currDev = (Skeleton *)(collector->dev);
+    currDev->x = 0;
+}
+
 static DevVtbl vtbl = {Skeleton_test,
                        Skeleton_makeEvt,
                        Skeleton_update,
-                       Skeleton_updateRaw};
+                       Skeleton_updateRaw,
+                       Skeleton_clear};
 
 /* ---------------------------- Global functions --------------------------- */
 Device *

--- a/src/device/src/device.c
+++ b/src/device/src/device.c
@@ -77,7 +77,8 @@ device_updateRaw(Device *const me)
 void 
 device_clear(Device *const me)
 {
-    if ((me != (Device *)0) && (me->vptr->clear != (ClearOper)0))
+    if ((me != (Device *)0)                     /* device is not connected */
+         && (me->vptr->clear != (ClearOper)0))  /* oper is not implemented */
     {
         (*me->vptr->clear)(me);
     }

--- a/src/device/src/device.c
+++ b/src/device/src/device.c
@@ -74,4 +74,13 @@ device_updateRaw(Device *const me)
     (*me->vptr->updateRaw)(me);
 }
 
+void 
+device_clear(Device *const me)
+{
+    if ((me != (Device *)0) && (me->vptr->clear != (ClearOper)0))
+    {
+        (*me->vptr->clear)(me);
+    }
+}
+
 /* ------------------------------ End of file ------------------------------ */

--- a/src/device/src/sprayer.c
+++ b/src/device/src/sprayer.c
@@ -93,7 +93,8 @@ sprayer_updateRaw(Device *const me)
 static DevVtbl vtbl = {sprayer_test,
                        sprayer_makeEvt,
                        sprayer_update,
-                       sprayer_updateRaw};
+                       sprayer_updateRaw,
+                       (ClearOper)0};
 
 /* ---------------------------- Global functions --------------------------- */
 Device *

--- a/src/device/test/test_Harvest.c
+++ b/src/device/test/test_Harvest.c
@@ -233,4 +233,36 @@ test_TestOperation(void)
     TEST_ASSERT_EQUAL(true, result);
 }
 
+void
+test_ClearAttributes(void)
+{
+    Device *dev;                    /* collector attribute */
+    Collector *me;
+    Harvest *harvest;
+
+    device_ctor_Expect(HarvestSpy_getObj(),
+                       HARVEST,
+                       (RKH_SMA_T *)collector,
+                       (JobCond *)0,
+                       (DevVtbl *)0);
+    device_ctor_IgnoreArg_jobCond();
+    device_ctor_IgnoreArg_vtbl();
+    device_ctor_StubWithCallback(Mock_device_ctor_Callback);
+
+    me = RKH_DOWNCAST(Collector, collector);
+    dev = Harvest_ctor(0);
+
+    ((Harvest *)dev)->hoard = 4;
+    ((Harvest *)dev)->nPail = 5;
+    ((Harvest *)dev)->flow = 6;
+
+    (*dev->vptr->clear)(dev);
+
+    harvest = (Harvest *)me->dev;
+    TEST_ASSERT_EQUAL(dev, me->dev);
+    TEST_ASSERT_EQUAL(0, harvest->hoard);
+    TEST_ASSERT_EQUAL(0, harvest->nPail);
+    TEST_ASSERT_EQUAL(0, harvest->flow);
+}
+
 /* ------------------------------ End of file ------------------------------ */

--- a/src/device/test/test_Harvest.c
+++ b/src/device/test/test_Harvest.c
@@ -163,9 +163,6 @@ void
 test_UpdateOperation(void)
 {
     Device *dev;
-    uint16_t hoardExpect = 2;
-    uint16_t nPailExpect = 4;
-    uint16_t flowExpect = 6;
     EvtHarvestData evtHarvestData;
     RKH_EVT_T *evt;
     Harvest *harvest;
@@ -184,19 +181,23 @@ test_UpdateOperation(void)
 
     dev = Harvest_ctor(0);
 
-    evtHarvestData.base.dev = dev;
-    evtHarvestData.hoard = hoardExpect;
-    evtHarvestData.nPail = nPailExpect;
-    evtHarvestData.flow = flowExpect;
+    ((Harvest *)dev)->hoard = 1;
+    ((Harvest *)dev)->nPail = 2;
+    ((Harvest *)dev)->flow = 3;
+
+    evtHarvestData.base.dev = dev;  /* Receiving an evEvtDevData */
+    evtHarvestData.hoard = 4;
+    evtHarvestData.nPail = 5;
+    evtHarvestData.flow = 6;
     evt = (RKH_EVT_T *)&evtHarvestData;
 
     result = (*dev->vptr->update)(dev, evt);
 
     harvest = (Harvest *)me->dev;
     TEST_ASSERT_EQUAL(dev, me->dev);
-    TEST_ASSERT_EQUAL(hoardExpect, harvest->hoard);
-    TEST_ASSERT_EQUAL(nPailExpect, harvest->nPail);
-    TEST_ASSERT_EQUAL(flowExpect, harvest->flow);
+    TEST_ASSERT_EQUAL(1 + 4, harvest->hoard);
+    TEST_ASSERT_EQUAL(2 + 5, harvest->nPail);
+    TEST_ASSERT_EQUAL(3 + 6, harvest->flow);
     TEST_ASSERT_EQUAL(false, result);
 }
 

--- a/src/device/test/test_Sampler.c
+++ b/src/device/test/test_Sampler.c
@@ -245,4 +245,24 @@ test_TestOperation(void)
     TEST_ASSERT_EQUAL(false, result);
 }
 
+void
+test_UndefinedClearOperation(void)
+{
+    Device *dev;                    /* collector attribute */
+
+    device_ctor_Expect(SamplerSpy_getObj(),
+                       SAMPLER,
+                       (RKH_SMA_T *)collector,
+                       (JobCond *)0,
+                       (DevVtbl *)0);
+    device_ctor_IgnoreArg_jobCond();
+    device_ctor_IgnoreArg_vtbl();
+    device_ctor_StubWithCallback(Mock_device_ctor_Callback);
+
+    dev = Sampler_ctor();
+
+    TEST_ASSERT_NOT_NULL(dev);
+    TEST_ASSERT_NULL(dev->vptr->clear);
+}
+
 /* ------------------------------ End of file ------------------------------ */

--- a/src/device/test/test_Skeleton.c
+++ b/src/device/test/test_Skeleton.c
@@ -205,4 +205,31 @@ test_TestOperation(void)
     TEST_ASSERT_EQUAL(false, result);
 }
 
+void
+test_ClearOperation(void)
+{
+    Device *dev;
+    int xExpect = 0;
+    Skeleton *skeleton;
+    Collector *me;
+
+    me = RKH_DOWNCAST(Collector, collector);
+    device_ctor_Expect(SkeletonSpy_getObj(),
+                       SKELETON,
+                       (RKH_SMA_T *)collector,
+                       (JobCond *)0,
+                       (DevVtbl *)0);
+    device_ctor_IgnoreArg_jobCond();
+    device_ctor_IgnoreArg_vtbl();
+    device_ctor_StubWithCallback(Mock_device_ctor_Callback);
+
+    dev = Skeleton_ctor(4);
+
+    (*dev->vptr->clear)(dev);
+
+    skeleton = (Skeleton *)me->dev;
+    TEST_ASSERT_EQUAL(dev, me->dev);
+    TEST_ASSERT_EQUAL(xExpect, skeleton->x);
+}
+
 /* ------------------------------ End of file ------------------------------ */

--- a/src/device/test/test_device.c
+++ b/src/device/test/test_device.c
@@ -122,6 +122,13 @@ DevA_updateRaw(Device *const me)
     ((Collector *)(me->collector))->status.data.devData.a.z = ((DevA *)me)->y;
 }
 
+static void
+DevA_clear(Device *const me)
+{
+    ((DevA *)me)->x = 0;
+    ((DevA *)me)->y = 0;
+}
+
 static Device *
 DevA_ctor(int xMin, int xMax, int yMin) /* Parameters of job condition */
 {
@@ -129,7 +136,8 @@ DevA_ctor(int xMin, int xMax, int yMin) /* Parameters of job condition */
     static DevVtbl vtbl = {DevA_test,
                            DevA_makeEvt,
                            DevA_update,
-                           DevA_updateRaw};
+                           DevA_updateRaw,
+                           DevA_clear};
 
     DevA *me = &devA;
     device_ctor((Device *)me, DEVA, (RKH_SMA_T *)collector,
@@ -295,6 +303,54 @@ test_UpdateRawData(void)
     device_updateRaw(dev);
     TEST_ASSERT_EQUAL(4, me->status.data.devData.a.y);
     TEST_ASSERT_EQUAL(8, me->status.data.devData.a.z);
+}
+
+void
+test_ClearDeviceAttributes(void)
+{
+    Device *dev;                    /* collector attribute */
+    Collector *me;
+
+    me = RKH_DOWNCAST(Collector, collector);
+    devAObj = DevA_ctor(2, 8, 3);   /* from main() */
+    me->dev = devAObj;              /* connected device */
+    dev = me->dev;
+    ((DevA *)dev)->x = 4;
+    ((DevA *)dev)->y = 5;
+
+    device_clear(dev);
+
+    TEST_ASSERT_EQUAL(DEVA, dev->id);
+    TEST_ASSERT_EQUAL(0, ((DevA *)dev)->x);
+    TEST_ASSERT_EQUAL(0, ((DevA *)dev)->y);
+}
+
+void
+test_CallClearWithNullDevice(void)
+{
+    Device *dev;                    /* collector attribute */
+    Collector *me;
+
+    me = RKH_DOWNCAST(Collector, collector);
+    me->dev = (Device *)0;          /* there is no device connected */
+    dev = me->dev;
+
+    device_clear(dev);
+}
+
+void
+test_CallClearWithoutClearOperation(void)
+{
+    Device *dev;                    /* collector attribute */
+    Collector *me;
+
+    me = RKH_DOWNCAST(Collector, collector);
+    devAObj = DevA_ctor(2, 8, 3);   /* from main() */
+    me->dev = devAObj;              /* connected device */
+    dev = me->dev;
+    dev->vptr->clear = (ClearOper)0;    /* undefined clear operation */
+
+    device_clear(dev);
 }
 
 /* ------------------------------ End of file ------------------------------ */

--- a/src/device/test/test_sprayer.c
+++ b/src/device/test/test_sprayer.c
@@ -237,4 +237,24 @@ test_TestOperation(void)
     TEST_ASSERT_EQUAL(1, result);
 }
 
+void
+test_UndefinedClearOperation(void)
+{
+    Device *dev;                    /* collector attribute */
+
+    device_ctor_Expect(sprayerSpy_getObj(),
+                       SPRAYER,
+                       (RKH_SMA_T *)collector,
+                       (JobCond *)0,
+                       (DevVtbl *)0);
+    device_ctor_IgnoreArg_jobCond();
+    device_ctor_IgnoreArg_vtbl();
+    device_ctor_StubWithCallback(Mock_device_ctor_Callback);
+
+    dev = sprayer_ctor(5);
+
+    TEST_ASSERT_NOT_NULL(dev);
+    TEST_ASSERT_NULL(dev->vptr->clear);
+}
+
 /* ------------------------------ End of file ------------------------------ */

--- a/src/settings.h
+++ b/src/settings.h
@@ -39,7 +39,7 @@ extern "C" {
 #define MAP_TIME_ON_RUNNING_DFT         3
 #define MAP_TIME_ON_STOPPED_DFT         60
 #define CONN_TIME_DFT                   60
-#define DEV_POLL_CYCLE_TIME_DFT         1
+#define DEV_POLL_CYCLE_TIME_DFT         1000
 #define MAX_NUM_FRAMES_TO_SEND_DFT      100
 #define UPDATE_GPS_TIME                 2
 #define DFT_DIG_OUT_DFT                 0

--- a/src/signals.c
+++ b/src/signals.c
@@ -76,7 +76,7 @@ signals_publishSymbols(void)
     RKH_TR_FWK_SIG(evDigInChanged);
     RKH_TR_FWK_SIG(evDigOutChanged);
     RKH_TR_FWK_SIG(evRestart);
-    RKH_TR_FWK_SIG(evEndOfCycle);
+    RKH_TR_FWK_SIG(evEndOfPolling);
     RKH_TR_FWK_SIG(evSensorData);
     RKH_TR_FWK_SIG(evTerminate);
     RKH_TR_FWK_SIG(evDevData);

--- a/src/signals.h
+++ b/src/signals.h
@@ -76,7 +76,7 @@ enum Signals
     evTurn,
     evDigInChanged,
     evRestart,
-    evEndOfCycle,
+    evEndOfPolling,
     evSensorData,
     evTerminate,     /* press the key escape on the keyboard */
     evDevData,

--- a/src/tpsens/tplink/tplcfg.h
+++ b/src/tpsens/tplink/tplcfg.h
@@ -76,8 +76,8 @@
 
 #if (TPLINK_VAR_FRMTOUT == 0)
 #ifndef TPLINK_FRMTOUT_DFT
-#define TPLINK_FRMTOUT_DFT      (1000 / TPLINK_BASE_TIME) /* Inter Frame timeout
-                                                           * in ms */
+#define TPLINK_FRMTOUT_DFT      (200 / TPLINK_BASE_TIME) /* Inter Frame timeout
+                                                          * in ms */
 #endif
 #endif
 


### PR DESCRIPTION
- [x] Add a clear operation in Device class to clear its attributes. It will be used in Harvest devices in order to synchronize (clear) their attributes every mapping time seconds
- [x] Add the clear operation in every device class and set it up as an undefined operation (NULL)
- [x] Implement Harvest's clear operation to reset its attributes
- [x] Modify Harvest's update operation to add unconditionally its attribute values with the received values. It means every time this operation is called
- [x] Call device clear operation from Collector
- [x] Validate new and modified Harvest's operations using hw
- [x] Update DeviceMgr's state machine in order to start the device polling together with a timer
- [x] Change DLL packet timeout to 200ms
- [x] Validate DeviceMgr's state machine using hw